### PR TITLE
Remove redundant Map.set

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -46,7 +46,6 @@ export default function intersect<T>(arrays: ReadonlyArray<T>[], hash=default_ha
   return arrays[0].filter(e => {
     const hashed = hash(e);
     const count = set.get(hashed);
-    if (count !== undefined) set.set(hashed, 0);
     return count === arrays.length
   });
 }


### PR DESCRIPTION
We don't use this map anymore after that point, so, no reason to set value.